### PR TITLE
Allow jquery deferred with new-cap rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,7 +105,12 @@ module.exports = {
         "key-spacing": "error",
         "keyword-spacing": "error",
         "lines-around-directive": "error",
-        "new-cap": "error",
+        "new-cap": [
+            "error",
+            {
+                "capIsNewExceptions": ["$.Deferred", "jQuery.Deferred"]
+            }
+        ],
         "new-parens": "error",
         "newline-before-return": "error",
         "no-lonely-if": "error",


### PR DESCRIPTION
Currently you can't use `$.Deffered()` as it errors with `new-cap`