### PR TITLE
Add rule for arrow spacing

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,12 +77,7 @@ module.exports = {
             "error",
             "never"
         ],
-        "arrow-spacing": [
-            "error", {
-                "before": true,
-                "after": true
-            }
-        ],
+        "arrow-spacing": "error",
         "curly": "error",
         "eqeqeq": "error",
         "capitalized-comments": "error",

--- a/index.js
+++ b/index.js
@@ -77,6 +77,12 @@ module.exports = {
             "error",
             "never"
         ],
+        "arrow-spacing": [
+            "error", {
+                "before": true,
+                "after": true
+            }
+        ],
         "curly": "error",
         "eqeqeq": "error",
         "capitalized-comments": "error",


### PR DESCRIPTION
Should be:

```js
    openOverlay = () => {
```

Not:

```js
    openOverlay = ()=> {
    openOverlay = ()=>{
    openOverlay = () =>{
```