### PR TITLE
Add new object style for import and exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,10 @@ module.exports = {
         ],
         "max-len": [
             "error",
-            120
+            120,
+            {
+                "ignorePattern": "^import\\s.+\\sfrom\\s.+;$",
+            }
         ],
         "max-statements-per-line": [
             "error",
@@ -67,12 +70,21 @@ module.exports = {
             "error",
             "always"
         ],
-        "object-curly-newline": [
-            "error",
-            {
+        "object-curly-newline": ["error", {
+            "ObjectExpression": {
+                "minProperties": 1
+            },
+            "ObjectPattern": {
+                "minProperties": 1
+            },
+            "ImportDeclaration": "never",
+            "ExportDeclaration": {
                 "minProperties": 1
             }
-        ],
+        }],
+        "object-property-newline": ["error", {
+            "allowAllPropertiesOnSameLine": true
+        }],
         "space-before-function-paren": [
             "error",
             "never"
@@ -120,7 +132,6 @@ module.exports = {
         "no-underscore-dangle": "error",
         "no-unneeded-ternary": "error",
         "no-whitespace-before-property": "error",
-        "object-property-newline": "error",
         "space-before-blocks": "error",
         "space-in-parens": "error",
         "space-infix-ops": "error",

--- a/test/object.js
+++ b/test/object.js
@@ -1,0 +1,15 @@
+import { import1, import2 } from 'test';
+import import3 from 'test-import/with-very-long-name/with-very-long-name/with-very-long-name/with-very-long-name/with-very-long-name';
+
+var test1 = {};
+
+var test2 = {
+    import1,
+    import2,
+    import3
+};
+
+export {
+    test1 as Test1,
+    test2 as Test2
+};


### PR DESCRIPTION
Allow imports to be singleline e.g.:


Before:

```js
import React from 'react';
import PropTypes from 'prop-types';
import {
    CRS
} from 'leaflet';
import {
    Map, Polyline, Tooltip
} from 'react-leaflet';
import {
    observer
} from 'mobx-react';
import {
    action, observable, toJS
} from 'mobx';
import Seat from '../components/seat.js';
import Translator from '../../services/translator';
```

After:

```js
import React from 'react';
import PropTypes from 'prop-types';
import { CRS } from 'leaflet';
import { Map, Polyline, Tooltip } from 'react-leaflet';
import { observer } from 'mobx-react';
import { action, observable, toJS } from 'mobx';
import Seat from '../components/seat.js';
import Translator from '../../services/translator';
```