### PR TITLE
Add comma dangle for multiline array and objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,6 +89,13 @@ module.exports = {
             "error",
             "never"
         ],
+        "comma-dangle": ["error", {
+            "arrays": "always-multiline",
+            "objects": "always-multiline",
+            "imports": "always-multiline",
+            "exports": "always-multiline",
+            "functions": "never"
+        }],
         "arrow-spacing": "error",
         "curly": "error",
         "eqeqeq": "error",
@@ -110,7 +117,6 @@ module.exports = {
         "camelcase": "error",
         "comma-spacing": "error",
         "comma-style": "error",
-        "comma-dangle": "error",
         "computed-property-spacing": "error",
         "eol-last": "error",
         "func-call-spacing": "error",

--- a/test/comma-dangle.js
+++ b/test/comma-dangle.js
@@ -1,0 +1,29 @@
+/* eslint-disable object-curly-newline */
+import { importSingleLine } from 'hello';
+import {
+    importMultiline1,
+    importMultiline2,
+} from 'hello';
+
+var singleLine = { comma: 'dangle' };
+
+var multiLine = {
+    comma: 'dangle',
+};
+
+var arraySingleLine = [1, 2];
+
+var arrayMultiLine = [
+    1,
+    2,
+];
+
+export {
+    importSingleLine,
+    importMultiline1,
+    importMultiline2,
+    singleLine,
+    multiLine,
+    arraySingleLine,
+    arrayMultiLine,
+};

--- a/test/object.js
+++ b/test/object.js
@@ -6,10 +6,10 @@ var test1 = {};
 var test2 = {
     import1,
     import2,
-    import3
+    import3,
 };
 
 export {
     test1 as Test1,
-    test2 as Test2
+    test2 as Test2,
 };


### PR DESCRIPTION
This will force to use comma dangle on multiline object and arrays.
See test file for the new correct syntax.

Comma dangles are supported [since IE9](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas) so the browser compatibility should not make any problems also because uglify and babel would remove them. But in case of git comma dangles have some advantages when blaming a file.